### PR TITLE
Chore: add public key

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,6 @@
 {
   "manifest_version": 3,
+  "key":"MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6ug7k8VXtIZgMEyZUPwsn1ubPUnwkIpcQy9bqh7qsCMHLD+p+exSPM0dxIZrV1j/DzhLCMwh5I5K6STycyL5eNficKK7LQeB/IzGbxRCGbDcdmY+nCNLyilwuEDOJ1zCFMKwZ3X2gX1++vfWi64XGAcBi+aM//sREyIaeGsjsIwxwOUrY1eOaiAPQQJw9O7tQ9/zO4D7YOUC00GVasrLysEuJGMwRuj5tL7Rh5gH9o6uEXvR0F95kDPVbOJykjBuNua1Cv7V7sfTw0TXBgOlCpiDX1/m3o63xLmUGGWUWpKmFSFzVSoWTr1xgOm6EMRO9amSQZj7CZicfmVqSo/YQwIDAQAB",
   "name": "__MSG_extName__",
   "description": "__MSG_extDesc__",
   "default_locale": "en",


### PR DESCRIPTION
# Description
Adds public key in `manifest.json` for creating consistent keys when building from source ([ref](https://developer.chrome.com/docs/extensions/reference/manifest/key))

# Test Instructions
- Switch to branch `chore/add-public-key`.
- Build through the command `npm run build` or `npm run dev`.
- Load extension to Chrome. The ID should be `ojmbobnoagdgblhpbemfamfkcfjdfejl`

# Example Screenshot
![Screenshot 2025-07-09 at 6 32 24 PM](https://github.com/user-attachments/assets/2c3d9c00-b354-47ad-b78e-0c62ed07c6f8)
