### PR TITLE
Check user logout event using cookie value change

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -17,7 +17,10 @@
     "48": "assets/img/icon-48.png",
     "128": "assets/img/icon-128.png"
   },
-  "host_permissions": ["<all_urls>"],
+  "host_permissions": [
+    "https://app.godam.io/*",
+    "https://app-godam.rt.gw/*"
+  ],
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
@@ -98,7 +101,8 @@
     "downloads",
     "tabs",
     "tabCapture",
-    "scripting"
+    "scripting",
+    "cookies"
   ],
   "optional_permissions": ["offscreen", "desktopCapture", "alarms"]
 }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1910,8 +1910,8 @@ chrome.cookies.onChanged.addListener((changeInfo) => {
     if (cookie.domain.includes(domain)) {
         if ( (cookie.name === "sid" && cookie.value === "Guest") || (cookie.name === "user_id" && cookie.value === "Guest") ) {
             // If sid is Guest, clear the godamToken and godamRefreshToken.
-            chrome.storage.local.remove(["godamToken", "godamRefreshToken"], () => {
-                console.log("Cleared godamToken and godamRefreshToken");
+            chrome.storage.local.remove(["godamToken", "godamRefreshToken", "godamTokenExpiration"], () => {
+                console.log("User has been logged out since they logged out from https://app.godam.io");
             });
         }
     }

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1898,3 +1898,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         return true;
     }
 });
+
+chrome.cookies.onChanged.addListener((changeInfo) => {
+    const baseUrl = process.env.GODAM_BASE_URL || 'https://app.godam.io';
+    const domain = new URL(baseUrl).hostname; // Extract the domain part
+
+    const { cookie } = changeInfo;
+
+    console.log("Cookie changed:", cookie);
+
+    if (cookie.domain.includes(domain)) {
+        if ( (cookie.name === "sid" && cookie.value === "Guest") || (cookie.name === "user_id" && cookie.value === "Guest") ) {
+            // If sid is Guest, clear the godamToken and godamRefreshToken.
+            chrome.storage.local.remove(["godamToken", "godamRefreshToken"], () => {
+                console.log("Cleared godamToken and godamRefreshToken");
+            });
+        }
+    }
+});


### PR DESCRIPTION
This pull request updates the Chrome extension to improve cookie management and tighten host permissions. The main changes include restricting which sites the extension can access, adding the `cookies` permission, and introducing logic to clear authentication tokens when a user is identified as a guest.

**Permissions and host access:**

* Restricted `host_permissions` in `manifest.json` to only allow access to `https://app.godam.io/*` and `https://app-godam.rt.gw/*` instead of all URLs.
* Added the `cookies` permission to `manifest.json` to enable the extension to monitor and interact with browser cookies.

**Cookie and authentication handling:**

* Added a listener in `src/pages/Background/index.js` for cookie changes. If the `sid` or `user_id` cookie is set to `"Guest"` for the Godam domain, the extension automatically clears `godamToken` and `godamRefreshToken` from local storage to ensure guest users are not treated as authenticated.