### PR TITLE
Fix the playground page logout issue

### DIFF
--- a/src/pages/Content/Content.jsx
+++ b/src/pages/Content/Content.jsx
@@ -8,6 +8,20 @@ import ContentState from "./context/ContentState";
 
 const Content = () => {
 
+  // Check if user is logged in to GoDAM
+  useEffect(() => {
+    const checkLogin = async () => {
+      // Check if user is logged in to GoDAM.
+      const { godamToken } = await chrome.storage.local.get(["godamToken"]);
+
+      if (!godamToken) {
+          // Store the current tab ID before opening login page.
+          window.location.href = chrome.runtime.getURL("login.html");
+      }
+    }
+    checkLogin();
+  }, []);
+
   return (
     <div className="screenity-shadow-dom">
       <ContentState>

--- a/src/pages/Content/popup/layout/SettingsMenu.jsx
+++ b/src/pages/Content/popup/layout/SettingsMenu.jsx
@@ -632,8 +632,10 @@ const SettingsMenu = (props) => {
                 chrome.runtime.sendMessage({ type: "sign-out-godam" });
                 // Close the dropdown
                 props.setOpen(false);
-                // Refresh the page
-                window.location.reload();
+                // Refresh the page, and wait for the sign-out process to complete
+                setTimeout(() => {
+                  window.location.reload();
+                }, 1000);
               }}
             >
               <span style={{ marginRight: "8px" }}>

--- a/src/pages/Login/Setup.jsx
+++ b/src/pages/Login/Setup.jsx
@@ -10,24 +10,17 @@ const Setup = () => {
   const [loaderProgress, setLoaderProgress] = useState(100);
 
   useEffect(() => {
-    // Inject content script
-    const script = document.createElement("script");
-    script.src = chrome.runtime.getURL("contentScript.bundle.js");
-    script.async = true;
-    document.body.appendChild(script);
-
-    // Also inject CSS
-    const style = document.createElement("link");
-    style.rel = "stylesheet";
-    style.type = "text/css";
-    style.href = chrome.runtime.getURL("assets/fonts/fonts.css");
-    document.body.appendChild(style);
-
-    // Return
-    return () => {
-      document.body.removeChild(script);
-      document.body.removeChild(style);
-    };
+    const checkLogin = async () => {
+    
+      // Check if user is logged in to GoDAM
+      const { godamToken } = await chrome.storage.local.get(["godamToken"]);
+    
+      if (godamToken) {
+        // Redirect to playground page if user is logged in
+        window.location.href = chrome.runtime.getURL("playground.html");
+      }
+    }
+    checkLogin();
   }, []);
 
   useEffect(() => {
@@ -64,12 +57,17 @@ const Setup = () => {
           // Get the previous tab ID from storage and navigate back to it
           chrome.storage.local.get(['previousTabId'], (result) => {
             if (result.previousTabId) {
+              console.log(result);
+              
               chrome.tabs.update(result.previousTabId, { active: true });
               // Clear the stored tab ID
               chrome.storage.local.remove('previousTabId');
 
               // Close the current window
               window.close();
+            } else {
+              // If no previous tab ID is found, redirect to the default page
+              window.location.href = chrome.runtime.getURL("playground.html");
             }
           });
         }, 3000);


### PR DESCRIPTION
This pull request introduces improvements to user authentication flow and session management in the Chrome extension, focusing on ensuring users are properly redirected based on their login state. The main changes include adding login checks, updating redirect logic, and improving the sign-out process.

**Authentication and Redirect Logic:**

* Added a login check in `Content.jsx` to verify if the user is logged in to GoDAM; if not, the user is redirected to the login page.
* Updated `Setup.jsx` to check for an existing login session on load; if already logged in, the user is redirected to the `playground.html` page instead of injecting scripts and styles.

**Sign-out and Session Handling:**

* Improved the sign-out process in `SettingsMenu.jsx` by adding a delay before reloading the page, ensuring the sign-out operation completes before the UI refreshes.
* Enhanced tab navigation after login in `Setup.jsx`: if the previous tab ID is not found, the user is redirected to the default `playground.html` page as a fallback.

**Closes:** #45 