### PR TITLE
Fix: No video devices invoking permission issue modal

### DIFF
--- a/src/pages/Content/context/ContentState.jsx
+++ b/src/pages/Content/context/ContentState.jsx
@@ -506,6 +506,17 @@ const ContentState = (props) => {
             micActive: true,
           });
         }
+        else{
+          setContentState((prevContentState) => ({
+            ...prevContentState,
+            defaultAudioInput: "none",
+            micActive: false,
+          }));
+          chrome.storage.local.set({
+            defaultAudioInput: "none",
+            micActive: false,
+          });
+        }
         if (videoInput.length > 0) {
           setContentState((prevContentState) => ({
             ...prevContentState,
@@ -517,6 +528,17 @@ const ContentState = (props) => {
             cameraActive: true,
           });
         }
+        else {
+          setContentState((prevContentState) => ({
+            ...prevContentState,
+            defaultVideoInput: "none",
+            cameraActive: false,
+          }));
+          chrome.storage.local.set({
+            defaultVideoInput: "none",
+            cameraActive: false,
+          });
+        }
         if (audioInput.length > 0 || videoInput.length > 0) {
           setContentState((prevContentState) => ({
             ...prevContentState,
@@ -524,6 +546,15 @@ const ContentState = (props) => {
           }));
           chrome.storage.local.set({
             setDevices: true,
+          });
+        }
+        else{
+          setContentState((prevContentState) => ({
+            ...prevContentState,
+            setDevices: false,
+          }));
+          chrome.storage.local.set({
+            setDevices: false,
           });
         }
       }

--- a/src/pages/Content/context/ContentState.jsx
+++ b/src/pages/Content/context/ContentState.jsx
@@ -28,13 +28,13 @@ const ContentState = (props) => {
     if (!locale.includes("en")) {
       setURL(
         "https://translate.google.com/translate?sl=en&tl=" +
-          locale +
-          "&u=https://godam.io/features/godam-screen-recorder/"
+        locale +
+        "&u=https://godam.io/features/godam-screen-recorder/"
       );
       setURL2(
         "https://translate.google.com/translate?sl=en&tl=" +
-          locale +
-          "&u=https://godam.io/features/godam-screen-recorder/"
+        locale +
+        "&u=https://godam.io/features/godam-screen-recorder/"
       );
     }
   }, []);
@@ -136,7 +136,7 @@ const ContentState = (props) => {
       if (!dismiss) {
         contentStateRef.current.openToast(
           chrome.i18n.getMessage("pausedRecordingToast"),
-          function () {}
+          function () { }
         );
       }
     }, 100);
@@ -233,7 +233,7 @@ const ContentState = (props) => {
         if (data.quota < 524288000) {
           if (typeof contentStateRef.current.openModal === "function") {
             let clear = null;
-            let clearAction = () => {};
+            let clearAction = () => { };
             // Add help link to modal
             const locale = chrome.i18n.getMessage("@@ui_locale");
             let helpURL =
@@ -262,7 +262,7 @@ const ContentState = (props) => {
                   clear,
                   chrome.i18n.getMessage("permissionsModalDismiss"),
                   clearAction,
-                  () => {},
+                  () => { },
                   null,
                   chrome.i18n.getMessage("learnMoreDot"),
                   helpURL
@@ -302,7 +302,7 @@ const ContentState = (props) => {
                 await checkChromeCapturePermissionsSW();
                 startStreaming();
               },
-              () => {},
+              () => { },
               null,
               chrome.i18n.getMessage("learnMoreDot"),
               URL,
@@ -362,7 +362,7 @@ const ContentState = (props) => {
                   pipEnded: false,
                 }));
               },
-              () => {},
+              () => { },
               false,
               false,
               false,
@@ -491,72 +491,51 @@ const ContentState = (props) => {
         id: contentStateRef.current.defaultVideoInput,
       });
 
-      // Check if first time setting devices
-      if (!contentStateRef.current.setDevices) {
-        // Set default devices
-        // Check if audio devices exist
-        if (audioInput.length > 0) {
-          setContentState((prevContentState) => ({
-            ...prevContentState,
-            defaultAudioInput: audioInput[0].deviceId,
-            micActive: true,
-          }));
-          chrome.storage.local.set({
-            defaultAudioInput: audioInput[0].deviceId,
-            micActive: true,
-          });
-        }
-        else{
-          setContentState((prevContentState) => ({
-            ...prevContentState,
-            defaultAudioInput: "none",
-            micActive: false,
-          }));
-          chrome.storage.local.set({
-            defaultAudioInput: "none",
-            micActive: false,
-          });
-        }
-        if (videoInput.length > 0) {
-          setContentState((prevContentState) => ({
-            ...prevContentState,
-            defaultVideoInput: videoInput[0].deviceId,
-            cameraActive: true,
-          }));
-          chrome.storage.local.set({
-            defaultVideoInput: videoInput[0].deviceId,
-            cameraActive: true,
-          });
-        }
-        else {
-          setContentState((prevContentState) => ({
-            ...prevContentState,
-            defaultVideoInput: "none",
-            cameraActive: false,
-          }));
-          chrome.storage.local.set({
-            defaultVideoInput: "none",
-            cameraActive: false,
-          });
-        }
-        if (audioInput.length > 0 || videoInput.length > 0) {
-          setContentState((prevContentState) => ({
-            ...prevContentState,
-            setDevices: true,
-          }));
-          chrome.storage.local.set({
-            setDevices: true,
-          });
-        }
-        else{
-          setContentState((prevContentState) => ({
-            ...prevContentState,
-            setDevices: false,
-          }));
-          chrome.storage.local.set({
-            setDevices: false,
-          });
-        }
+      // Set default devices
+      // Check if audio devices exist
+      if (audioInput && audioInput.length > 0) {
+        setContentState((prevContentState) => ({
+          ...prevContentState,
+          defaultAudioInput: audioInput[0].deviceId,
+          micActive: true,
+        }));
+        chrome.storage.local.set({
+          defaultAudioInput: audioInput[0].deviceId,
+          micActive: true,
+        });
+      }
+      else {
+        setContentState((prevContentState) => ({
+          ...prevContentState,
+          defaultAudioInput: "none",
+          micActive: false,
+        }));
+        chrome.storage.local.set({
+          defaultAudioInput: "none",
+          micActive: false,
+        });
+      }
+      if (videoInput && videoInput.length > 0) {
+        setContentState((prevContentState) => ({
+          ...prevContentState,
+          defaultVideoInput: videoInput[0].deviceId,
+          cameraActive: true,
+        }));
+        chrome.storage.local.set({
+          defaultVideoInput: videoInput[0].deviceId,
+          cameraActive: true,
+        });
+      }
+      else {
+        setContentState((prevContentState) => ({
+          ...prevContentState,
+          defaultVideoInput: "none",
+          cameraActive: false,
+        }));
+        chrome.storage.local.set({
+          defaultVideoInput: "none",
+          cameraActive: false,
+        });
       }
     } else {
       setContentState((prevContentState) => ({
@@ -570,7 +549,7 @@ const ContentState = (props) => {
           chrome.i18n.getMessage("permissionsModalDescription"),
           chrome.i18n.getMessage("permissionsModalDismiss"),
           chrome.i18n.getMessage("permissionsModalNoShowAgain"),
-          () => {},
+          () => { },
           () => {
             noMorePermissions();
           },
@@ -635,7 +614,6 @@ const ContentState = (props) => {
     openToast: null,
     audioInput: [],
     videoInput: [],
-    setDevices: false,
     defaultAudioInput: "none",
     defaultVideoInput: "none",
     cameraActive: false,
@@ -1308,7 +1286,6 @@ const ContentState = (props) => {
         "askMicrophone",
         "offscreenRecording",
         "zoomEnabled",
-        "setDevices",
         "popupPosition",
         "surface",
         "hideUIAlerts",
@@ -1339,17 +1316,17 @@ const ContentState = (props) => {
               : prevContentState.videoInput,
           defaultAudioInput:
             result.defaultAudioInput !== undefined &&
-            result.defaultAudioInput !== null
+              result.defaultAudioInput !== null
               ? result.defaultAudioInput
               : prevContentState.defaultAudioInput,
           defaultVideoInput:
             result.defaultVideoInput !== undefined &&
-            result.defaultVideoInput !== null
+              result.defaultVideoInput !== null
               ? result.defaultVideoInput
               : prevContentState.defaultVideoInput,
           cameraDimensions:
             result.cameraDimensions !== undefined &&
-            result.cameraDimensions !== null
+              result.cameraDimensions !== null
               ? result.cameraDimensions
               : prevContentState.cameraDimensions,
           cameraFlipped:
@@ -1366,17 +1343,17 @@ const ContentState = (props) => {
               : prevContentState.micActive,
           backgroundEffect:
             result.backgroundEffect !== undefined &&
-            result.backgroundEffect !== null
+              result.backgroundEffect !== null
               ? result.backgroundEffect
               : prevContentState.backgroundEffect,
           backgroundEffectsActive:
             result.backgroundEffectsActive !== undefined &&
-            result.backgroundEffectsActive !== null
+              result.backgroundEffectsActive !== null
               ? result.backgroundEffectsActive
               : prevContentState.backgroundEffectsActive,
           toolbarPosition:
             result.toolbarPosition !== undefined &&
-            result.toolbarPosition !== null
+              result.toolbarPosition !== null
               ? result.toolbarPosition
               : prevContentState.toolbarPosition,
           countdown:
@@ -1425,12 +1402,12 @@ const ContentState = (props) => {
               : prevContentState.alarmTime,
           pendingRecording:
             result.pendingRecording !== undefined &&
-            result.pendingRecording !== null
+              result.pendingRecording !== null
               ? result.pendingRecording
               : prevContentState.pendingRecording,
           askForPermissions:
             result.askForPermissions !== undefined &&
-            result.askForPermissions !== null
+              result.askForPermissions !== null
               ? result.askForPermissions
               : prevContentState.askForPermissions,
           cursorMode:
@@ -1451,13 +1428,9 @@ const ContentState = (props) => {
               : prevContentState.askMicrophone,
           offscreenRecording:
             result.offscreenRecording !== undefined &&
-            result.offscreenRecording !== null
+              result.offscreenRecording !== null
               ? result.offscreenRecording
               : prevContentState.offscreenRecording,
-          setDevices:
-            result.setDevices !== undefined && result.setDevices !== null
-              ? result.setDevices
-              : prevContentState.setDevices,
           popupPosition:
             result.popupPosition !== undefined && result.popupPosition !== null
               ? result.popupPosition

--- a/src/pages/Permissions/Permissions.jsx
+++ b/src/pages/Permissions/Permissions.jsx
@@ -37,7 +37,10 @@ const Recorder = () => {
         cameraPermission.state === "granted" ||
         microphonePermission.state === "granted"
       ) {
-        await endStream();
+        await endStream(
+          cameraPermission.state === "granted",
+          microphonePermission.state === "granted"
+        );
         await enumerateDevices(
           cameraPermission.state === "granted",
           microphonePermission.state === "granted"
@@ -60,7 +63,7 @@ const Recorder = () => {
     }
   };
 
-  const endStream = async () =>{
+  const endStream = async (micGranted = true, camGranted = true) => {
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: micGranted,
@@ -72,10 +75,10 @@ const Recorder = () => {
       });
 
     } catch (error) {
-        console.error("Error ending stream")
-        console.error(error)
+      console.error("Error ending stream");
+      console.error(error);
     }
-  }
+  };
 
   // Enumerate devices
   const enumerateDevices = async (camGranted = true, micGranted = true) => {

--- a/src/pages/Permissions/Permissions.jsx
+++ b/src/pages/Permissions/Permissions.jsx
@@ -33,7 +33,8 @@ const Recorder = () => {
         cameraPermission.state === "granted" ||
         microphonePermission.state === "granted"
       ) {
-        enumerateDevices(
+        await endStream();
+        await enumerateDevices(
           cameraPermission.state === "granted",
           microphonePermission.state === "granted"
         );
@@ -50,17 +51,31 @@ const Recorder = () => {
         // sendResponse({ success: false, error: err.name });
       }
     } catch (err) {
-      enumerateDevices();
+      await endStream();
+      await enumerateDevices();
     }
   };
 
-  // Enumerate devices
-  const enumerateDevices = async (camGranted = true, micGranted = true) => {
+  const endStream = async () =>{
     try {
       const stream = await navigator.mediaDevices.getUserMedia({
         audio: micGranted,
         video: camGranted,
       });
+
+      stream.getTracks().forEach(function (track) {
+        track.stop();
+      });
+        
+    } catch (error) {
+        console.error("Error ending stream")
+        console.error(error)
+    }
+  }
+
+  // Enumerate devices
+  const enumerateDevices = async (camGranted = true, micGranted = true) => {
+    try {
 
       const devicesInfo = await navigator.mediaDevices.enumerateDevices();
 
@@ -122,10 +137,6 @@ const Recorder = () => {
 
       //sendResponse({ success: true, audioinput, audiooutput, videoinput });
 
-      // End the stream
-      stream.getTracks().forEach(function (track) {
-        track.stop();
-      });
     } catch (err) {
       // Post message to parent window
       window.parent.postMessage(

--- a/src/pages/Permissions/Permissions.jsx
+++ b/src/pages/Permissions/Permissions.jsx
@@ -28,6 +28,10 @@ const Recorder = () => {
         checkPermissions();
       };
 
+      navigator.mediaDevices.ondevicechange = () => {
+        checkPermissions();
+      }
+      
       // If the permissions are granted, enumerate devices
       if (
         cameraPermission.state === "granted" ||
@@ -66,7 +70,7 @@ const Recorder = () => {
       stream.getTracks().forEach(function (track) {
         track.stop();
       });
-        
+
     } catch (error) {
         console.error("Error ending stream")
         console.error(error)


### PR DESCRIPTION
# Bug Description
When no video devices are available, the extension shows a dialog for the permission issue.

# Fix Description
- Separate stream stopping and device enumeration. Stream stopping can fail without blocking device enumeration.
- Add device enumeration function to `ondevicechange` event.
- Removes `setDevices` state so that the device list can be updated.

# Testing instructions
## Create a scenario where no video devices are available
- Connect an external monitor.
- Close the lid of the laptop
- Click on the device (video or audio) dropdown
## Expected outcome
- Video dropdown should show no devices.
- Audio dropdown should show valid devices.
- No pop-up modal for device permission should appear.