### PR TITLE
Fix the automatic recording finalization issue for window, and fullscreen recording.

### DIFF
--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -735,16 +735,16 @@ const sendMessageRecord = async (message) => {
 
 const forwardAudioTrackWarning = async ({ source, reason }) => {
     try {
-        const { activeTab, tabRecordedID, recordingType } =
+        const { activeTab, tabRecordedID, recordingType, surface } =
             await chrome.storage.local.get([
                 "activeTab",
                 "tabRecordedID",
                 "recordingType",
+                "surface"
             ]);
 
-        const isScreenCapture = recordingType === "screen";
-
-        if (isScreenCapture) {
+        // Stop recording if surface window or monitor and recording type is screen and not in region mode
+        if (recordingType === "screen" && ( surface === "window" || surface === "monitor" ) ) {
             await sendMessageRecord({ type: "stop-recording-tab" });
             return;
         }

--- a/src/pages/Content/context/ContentState.jsx
+++ b/src/pages/Content/context/ContentState.jsx
@@ -1075,7 +1075,7 @@ const ContentState = (props) => {
           },
           () => {
             audioWarningShown.current = false;
-            contentStateRef.current.dismissRecording();
+            contentStateRef.current.stopRecording();
           }
         );
       } else if (request.type === "recording-check") {


### PR DESCRIPTION
* Simplified window, and fullscreen screen capture detection by removing the `tabPreferred` check from the `forwardAudioTrackWarning` function in `src/pages/Background/index.js`. 
* Allow to finalize the screen recording for window & fullscreen recording, and only show the warning message in case of tab screen recording.