### PR TITLE
Hotfix: screenshots CSP issue, for chrome extension tab

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -72,8 +72,8 @@
     "value": "same-origin"
   },
   "content_security_policy": {
-    "sandbox": "sandbox allow-scripts allow-modals allow-popups; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; object-src 'self';worker-src 'self' blob: ; connect-src 'self' https://*.posthog.com https://app.godam.io https://upload.godam.io https://cdn.plyr.io;",
-    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; media-src 'self' data: blob: *; connect-src 'self' https://*.posthog.com https://app.godam.io https://upload.godam.io https://cdn.plyr.io;"
+    "sandbox": "sandbox allow-scripts allow-modals allow-popups; script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:; object-src 'self';worker-src 'self' blob: ; connect-src 'self' data: blob: https://*.posthog.com https://app.godam.io https://upload.godam.io https://cdn.plyr.io;",
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'; media-src 'self' data: blob: *; connect-src 'self' data: blob: https://*.posthog.com https://app.godam.io https://upload.godam.io https://cdn.plyr.io;"
   },
   "sandbox": {
     "pages": [

--- a/src/pages/Background/index.js
+++ b/src/pages/Background/index.js
@@ -1974,9 +1974,6 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             options.rect = request.rect;
         }
 
-        console.log(options);
-
-
         // Capture the current tab
         chrome.tabs.captureVisibleTab(null, options, (dataUrl) => {
             if (chrome.runtime.lastError) {


### PR DESCRIPTION
This pull request makes a small update to the content security policy in the `src/manifest.json` file and removes a debug logging statement from the background script. 

Security and connectivity improvements:

* Updated the `sandbox` and `extension_pages` content security policy directives in `src/manifest.json` to allow connections to `data:` and `blob:` URLs, in addition to existing hosts.

Code cleanup:

* Removed an unnecessary `console.log(options);` statement from the background script in `src/pages/Background/index.js`.