### PR TITLE
Show annotation tools in screenshots

### DIFF
--- a/src/pages/Content/popup/layout/ScreenshotTab.jsx
+++ b/src/pages/Content/popup/layout/ScreenshotTab.jsx
@@ -353,7 +353,7 @@ const ScreenshotTab = ({onScreenshotComplete, shadowRef}) => {
                         color: '#fff',
                     }}
                     onClick={() => {
-                        const screenityRootContainer = document.getElementById('screenity-root-container'); 
+                        const screenityRootContainer = document.getElementById('screenity-root-container');
 
                         if (screenityRootContainer) {
                             screenityRootContainer.style.display = 'none';


### PR DESCRIPTION
This pull request makes a minor update to the screenshot functionality in the `ScreenshotTab` component. The change improves the code by referencing the correct DOM element when hiding the UI during a screenshot operation. 

* In `ScreenshotTab.jsx`, the code now targets `screenity-root-container` instead of `screenity-ui` to hide the appropriate container when a screenshot is initiated.
* This will allow us to show the annotation canvas in the screenshot.

## Screenshots
<img width="1470" height="715" alt="Screenshot 2025-12-03 at 11 50 34 AM" src="https://github.com/user-attachments/assets/acd7e229-0d61-43f1-8df2-298e0764d09a" />
<img width="1470" height="715" alt="Screenshot 2025-12-03 at 11 50 46 AM" src="https://github.com/user-attachments/assets/5bef9620-82d4-4e42-95c8-2e65dfac8eda" />
