### PR TITLE
Fix the gray background overlay from the screenshot

### DIFF
--- a/src/pages/Content/Wrapper.jsx
+++ b/src/pages/Content/Wrapper.jsx
@@ -137,6 +137,7 @@ const Wrapper = () => {
             !contentState.drawingMode &&
             !contentState.blurMode && (
               <div
+                id="screenity-ui-backdrop"
                 style={{
                   // all: "unset",
                   width: "100%",

--- a/src/pages/Content/popup/layout/ScreenshotTab.jsx
+++ b/src/pages/Content/popup/layout/ScreenshotTab.jsx
@@ -353,9 +353,11 @@ const ScreenshotTab = ({onScreenshotComplete, shadowRef}) => {
                         color: '#fff',
                     }}
                     onClick={() => {
+                        const screenityUIBackdrop = document.getElementById('screenity-ui-backdrop');
                         const screenityRootContainer = document.getElementById('screenity-root-container');
 
                         if (screenityRootContainer) {
+                            screenityUIBackdrop.style.background = 'none';
                             screenityRootContainer.style.display = 'none';
                         }
 


### PR DESCRIPTION
This pull request introduces a small UI improvement related to screenshot functionality. The main change is the addition of an `id` to a backdrop element, allowing it to be directly manipulated when taking screenshots.

UI and Screenshot Functionality:

* Added `id="screenity-ui-backdrop"` to the backdrop `div` in `Wrapper.jsx`, enabling direct DOM access for UI adjustments during screenshot actions.
* Updated `ScreenshotTab.jsx` to reset the backdrop's background style when hiding the root container, improving screenshot results.